### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/frankieron50845/6fabacec-a670-47ff-88f8-d0806c1c3f45/5e42a0ff-766a-4df0-9fce-b687e74fddc2/_apis/work/boardbadge/771d0514-d119-474c-9cc5-3e0345b95ef7)](https://dev.azure.com/frankieron50845/6fabacec-a670-47ff-88f8-d0806c1c3f45/_boards/board/t/5e42a0ff-766a-4df0-9fce-b687e74fddc2/Microsoft.RequirementCategory)
 ![logo](./previews/logo.png) <br />
 
 <p align="center">


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/frankieron50845/6fabacec-a670-47ff-88f8-d0806c1c3f45/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.